### PR TITLE
Parse table in `from _h5mu_to_spatialdata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 * Pin ome-zarr to 0.13.0 to avoid a chunk shape incompatibility with zarr 3.x (PR #48).
 
+## BUG FIXES
+
+* `convert/from_h5mu_to_spatialdata`: Make sure the AnnData table is properly parsed before inserting into the new SpatialData object (PR #53)
+
 # openpipeline_spatial 0.4.0
 
 ## NEW FUNCTIONALITY

--- a/src/convert/from_h5mu_to_spatialdata/script.py
+++ b/src/convert/from_h5mu_to_spatialdata/script.py
@@ -49,6 +49,19 @@ logger.info("Creating SpatialData object...")
 if par.get("input_spatialdata", None) is not None:
     logger.info("Using existing SpatialData...")
     sdata = sdata_existing
+
+    # Make sure mod is a compatible SpatialData table
+    attrs = mod.uns["spatialdata_attrs"]
+    mod = sd.models.TableModel.parse(
+        mod,
+        region=attrs["region"].tolist()
+        if hasattr(attrs["region"], "tolist")
+        else attrs["region"],
+        region_key=attrs["region_key"],
+        instance_key=attrs["instance_key"],
+        overwrite_metadata=True,
+    )
+
     sdata["table"] = mod
 else:
     logger.info("Creating new SpatialData...")

--- a/src/convert/from_h5mu_to_spatialdata/test.py
+++ b/src/convert/from_h5mu_to_spatialdata/test.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import mudata as mu
+import numpy as np
 import pytest
 import spatialdata as sd
 
@@ -136,6 +137,51 @@ def test_execution_without_input_spatialdata(run_component, tmp_path):
     )
     assert len(sdata.points) == 0, (
         "Expected no points when input_spatialdata is not provided."
+    )
+
+
+def test_execution_with_numpy_region(run_component, tmp_path):
+    """Test that a numpy array region in spatialdata_attrs is handled correctly."""
+    input_original = meta["resources_dir"] + "/xenium_tiny.h5mu"
+    input_spatialdata = meta["resources_dir"] + "/xenium_tiny.zarr"
+    output = tmp_path / "output_numpy_region.zarr"
+
+    # Read the original h5mu and force region to a numpy object array
+    mdata = mu.read_h5mu(input_original)
+    mod = mdata.mod["rna"]
+
+    attrs = mod.uns["spatialdata_attrs"]
+    region = attrs["region"]
+    region_list = (
+        region.tolist()
+        if hasattr(region, "tolist")
+        else (region if isinstance(region, list) else [region])
+    )
+    mod.uns["spatialdata_attrs"]["region"] = np.array(region_list, dtype=object)
+
+    input_modified = tmp_path / "modified_numpy_region.h5mu"
+    mdata.write_h5mu(str(input_modified))
+
+    run_component(
+        [
+            "--input",
+            str(input_modified),
+            "--input_spatialdata",
+            input_spatialdata,
+            "--output",
+            str(output),
+        ]
+    )
+    assert os.path.exists(output), "output zarr was not created"
+
+    sdata = sd.read_zarr(output)
+    table = sdata["table"]
+
+    assert table.n_obs == mod.n_obs, (
+        "The number of observations in the SpatialData table does not match the selected modality."
+    )
+    assert table.obs_names.equals(mod.obs_names), (
+        "The observation names in the SpatialData table do not match the selected modality."
     )
 
 


### PR DESCRIPTION
Update the `from_h5mu_to_spatialdata` component so that the `AnnData` table is parsed by `spatialdata.models.TableModel.parse()` before inserting into the base `SpatialData` object to make sure it is compatible.

Also, add a matching test case.