### PR TITLE
Add Visium HD tiny test resource script

### DIFF
--- a/resources_test_scripts/subset_visium_hd.py
+++ b/resources_test_scripts/subset_visium_hd.py
@@ -180,7 +180,9 @@ def stub_feature_slice(src_path, dst_path):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--input", required=True, help="extracted Space Ranger outs dir")
+    parser.add_argument(
+        "--input", required=True, help="extracted Space Ranger outs dir"
+    )
     parser.add_argument("--output", required=True, help="output tiny_spaceranger dir")
     parser.add_argument(
         "--dataset-id", required=True, help="feature_slice prefix / dataset id"
@@ -205,7 +207,9 @@ def main():
         os.makedirs(f"{out_dir}/spatial")
 
         positions = pd.read_parquet(f"{src_dir}/spatial/tissue_positions.parquet")
-        assert list(positions.columns) == TISSUE_POSITION_COLUMNS, list(positions.columns)
+        assert list(positions.columns) == TISSUE_POSITION_COLUMNS, list(
+            positions.columns
+        )
         region = positions[
             (positions.pxl_row_in_fullres >= row_min)
             & (positions.pxl_row_in_fullres <= row_max)

--- a/resources_test_scripts/subset_visium_hd.py
+++ b/resources_test_scripts/subset_visium_hd.py
@@ -6,7 +6,7 @@ bin size, column-subsetting the count matrices to the region's barcodes.
 feature_slice.h5 is reduced to an attrs-only stub (the reader only needs its
 metadata_json). Images are kept as-is (coords stay aligned via the unchanged
 scalefactor)."""
-import json
+
 import os
 import shutil
 import sys
@@ -15,33 +15,45 @@ import h5py
 import numpy as np
 import pandas as pd
 
-SRC = sys.argv[1]          # extracted outs dir
-OUT = sys.argv[2]          # output tiny_spaceranger dir
-DATASET_ID = sys.argv[3]   # feature_slice prefix / dataset id
+SRC = sys.argv[1]  # extracted outs dir
+OUT = sys.argv[2]  # output tiny_spaceranger dir
+DATASET_ID = sys.argv[3]  # feature_slice prefix / dataset id
 BINS = ["square_002um", "square_008um", "square_016um"]
 H5_FILES = ["filtered_feature_bc_matrix.h5", "raw_feature_bc_matrix.h5"]
-SPATIAL = ["tissue_positions.parquet", "scalefactors_json.json",
-           "tissue_hires_image.png", "tissue_lowres_image.png"]
-TP_COLS = ["barcode", "in_tissue", "array_row", "array_col",
-           "pxl_row_in_fullres", "pxl_col_in_fullres"]
+SPATIAL = [
+    "tissue_positions.parquet",
+    "scalefactors_json.json",
+    "tissue_hires_image.png",
+    "tissue_lowres_image.png",
+]
+TP_COLS = [
+    "barcode",
+    "in_tissue",
+    "array_row",
+    "array_col",
+    "pxl_row_in_fullres",
+    "pxl_col_in_fullres",
+]
 W = 22
 
 
 def choose_bbox():
-    tp = pd.read_parquet(f"{SRC}/binned_outputs/square_008um/spatial/tissue_positions.parquet")
+    tp = pd.read_parquet(
+        f"{SRC}/binned_outputs/square_008um/spatial/tissue_positions.parquet"
+    )
     R, C = int(tp.array_row.max()) + 1, int(tp.array_col.max()) + 1
     in_t = np.zeros((R, C), np.int64)
     exists = np.zeros((R, C), np.int64)
-    in_t[tp.array_row.values, tp.array_col.values] = (tp.in_tissue.values == 1)
+    in_t[tp.array_row.values, tp.array_col.values] = tp.in_tissue.values == 1
     exists[tp.array_row.values, tp.array_col.values] = 1
     It, Iv = in_t.cumsum(0).cumsum(1), exists.cumsum(0).cumsum(1)
 
-    def winsum(I, r0, c0):
+    def winsum(integral, r0, c0):
         r1, c1 = r0 + W - 1, c0 + W - 1
-        tot = I[r1, c1]
-        tot -= I[r0 - 1, c1] if r0 > 0 else 0
-        tot -= I[r1, c0 - 1] if c0 > 0 else 0
-        tot += I[r0 - 1, c0 - 1] if r0 > 0 and c0 > 0 else 0
+        tot = integral[r1, c1]
+        tot -= integral[r0 - 1, c1] if r0 > 0 else 0
+        tot -= integral[r1, c0 - 1] if c0 > 0 else 0
+        tot += integral[r0 - 1, c0 - 1] if r0 > 0 and c0 > 0 else 0
         return int(tot)
 
     best = None
@@ -58,12 +70,22 @@ def choose_bbox():
                     best = (score, r0, c0)
     assert best is not None, "no mixed-tissue window found"
     _, r0, c0 = best
-    blk = tp[(tp.array_row >= r0) & (tp.array_row < r0 + W) &
-             (tp.array_col >= c0) & (tp.array_col < c0 + W)]
-    print(f"  8um window at row[{r0},{r0+W}) col[{c0},{c0+W}): "
-          f"{len(blk)} bins, {int(blk.in_tissue.sum())} in-tissue")
-    return (blk.pxl_row_in_fullres.min(), blk.pxl_row_in_fullres.max(),
-            blk.pxl_col_in_fullres.min(), blk.pxl_col_in_fullres.max())
+    blk = tp[
+        (tp.array_row >= r0)
+        & (tp.array_row < r0 + W)
+        & (tp.array_col >= c0)
+        & (tp.array_col < c0 + W)
+    ]
+    print(
+        f"  8um window at row[{r0},{r0 + W}) col[{c0},{c0 + W}): "
+        f"{len(blk)} bins, {int(blk.in_tissue.sum())} in-tissue"
+    )
+    return (
+        blk.pxl_row_in_fullres.min(),
+        blk.pxl_row_in_fullres.max(),
+        blk.pxl_col_in_fullres.min(),
+        blk.pxl_col_in_fullres.max(),
+    )
 
 
 def subset_h5(src, dst, keep):
@@ -72,8 +94,11 @@ def subset_h5(src, dst, keep):
         cols = np.flatnonzero(np.isin(bc, list(keep)))
         indptr = f["matrix/indptr"][:]
         spans = [(int(indptr[j]), int(indptr[j + 1])) for j in cols]
-        points = (np.concatenate([np.arange(s, e) for s, e in spans])
-                  if spans else np.array([], dtype=indptr.dtype))
+        points = (
+            np.concatenate([np.arange(s, e) for s, e in spans])
+            if spans
+            else np.array([], dtype=indptr.dtype)
+        )
         new_indptr = np.zeros(len(cols) + 1, indptr.dtype)
         if spans:
             new_indptr[1:] = np.cumsum([e - s for s, e in spans])
@@ -86,7 +111,9 @@ def subset_h5(src, dst, keep):
                 m.attrs[k] = v
             m.create_dataset("barcodes", data=bc[cols], compression="gzip")
             m.create_dataset("data", data=f["matrix/data"][points], compression="gzip")
-            m.create_dataset("indices", data=f["matrix/indices"][points], compression="gzip")
+            m.create_dataset(
+                "indices", data=f["matrix/indices"][points], compression="gzip"
+            )
             m.create_dataset("indptr", data=new_indptr, compression="gzip")
             m.create_dataset("shape", data=np.array([n_feat, len(cols)], np.int32))
             f.copy(f["matrix/features"], m, name="features")
@@ -98,8 +125,10 @@ def main():
         shutil.rmtree(OUT)
     os.makedirs(OUT)
     # feature_slice stub at top level
-    with h5py.File(f"{SRC}/feature_slice.h5", "r") as s, \
-         h5py.File(f"{OUT}/{DATASET_ID}_feature_slice.h5", "w") as d:
+    with (
+        h5py.File(f"{SRC}/feature_slice.h5", "r") as s,
+        h5py.File(f"{OUT}/{DATASET_ID}_feature_slice.h5", "w") as d,
+    ):
         for k, v in s.attrs.items():
             d.attrs[k] = v
 
@@ -111,9 +140,12 @@ def main():
         os.makedirs(f"{odir}/spatial")
         tp = pd.read_parquet(f"{sdir}/spatial/tissue_positions.parquet")
         assert list(tp.columns) == TP_COLS, list(tp.columns)
-        region = tp[(tp.pxl_row_in_fullres >= rmin) & (tp.pxl_row_in_fullres <= rmax) &
-                    (tp.pxl_col_in_fullres >= cmin) & (tp.pxl_col_in_fullres <= cmax)
-                    ].reset_index(drop=True)
+        region = tp[
+            (tp.pxl_row_in_fullres >= rmin)
+            & (tp.pxl_row_in_fullres <= rmax)
+            & (tp.pxl_col_in_fullres >= cmin)
+            & (tp.pxl_col_in_fullres <= cmax)
+        ].reset_index(drop=True)
         region.to_parquet(f"{odir}/spatial/tissue_positions.parquet", index=False)
         keep = {x.encode() if isinstance(x, str) else x for x in region.barcode}
         nobs = {h: subset_h5(f"{sdir}/{h}", f"{odir}/{h}", keep) for h in H5_FILES}
@@ -121,9 +153,11 @@ def main():
         shutil.copy(f"{sdir}/spatial/scalefactors_json.json", f"{odir}/spatial/")
         shutil.copy(f"{sdir}/spatial/tissue_hires_image.png", f"{odir}/spatial/")
         shutil.copy(f"{sdir}/spatial/tissue_lowres_image.png", f"{odir}/spatial/")
-        print(f"  {b}: region {len(region)} bins | "
-              f"filtered={nobs['filtered_feature_bc_matrix.h5']} "
-              f"raw={nobs['raw_feature_bc_matrix.h5']}")
+        print(
+            f"  {b}: region {len(region)} bins | "
+            f"filtered={nobs['filtered_feature_bc_matrix.h5']} "
+            f"raw={nobs['raw_feature_bc_matrix.h5']}"
+        )
     os.system(f"du -sh {OUT}")
 
 

--- a/resources_test_scripts/subset_visium_hd.py
+++ b/resources_test_scripts/subset_visium_hd.py
@@ -1,32 +1,42 @@
-"""Crop a Visium HD SpaceRanger `outs` to a tiny tissue-straddling region.
+"""Crop a Visium HD Space Ranger ``outs`` directory down to a tiny test fixture.
 
-Picks a contiguous WxW window of 8um bins that mixes in/out of tissue (so raw
-keeps more bins than filtered), then applies that fullres pixel bbox to every
-bin size, column-subsetting the count matrices to the region's barcodes.
-feature_slice.h5 is reduced to an attrs-only stub (the reader only needs its
-metadata_json). Images are kept as-is (coords stay aligned via the unchanged
-scalefactor)."""
+A Visium HD slide bins the whole capture area into millions of 2 um squares, so
+even a downsampled dataset is far too large for CI. This script keeps only a
+small square region of the tissue:
 
+1. On the 8 um grid, find a contiguous ``WINDOW`` x ``WINDOW`` block of bins that
+   straddles the tissue edge -- i.e. it contains both in-tissue and background
+   bins. Keeping a mix means the *raw* matrix (all bins) ends up larger than the
+   *filtered* matrix (in-tissue bins only), which the downstream tests rely on.
+2. Convert that block to a full-resolution pixel bounding box and apply the same
+   box to every bin size (2 / 8 / 16 um), so the regions line up across bins.
+3. For each bin size, keep only the bins inside the box: filter
+   ``tissue_positions.parquet`` and column-subset the count matrices to those
+   barcodes.
+
+``feature_slice.h5`` is replaced by an attributes-only stub, because
+``spatialdata_io.visium_hd`` only reads its ``metadata_json`` attribute. The
+tissue images and scale factors are copied unchanged -- the bin coordinates
+still map onto them via the (unchanged) scale factor.
+
+Usage:
+    subset_visium_hd.py --input OUTS_DIR --output FIXTURE_DIR --dataset-id ID
+"""
+
+import argparse
 import os
 import shutil
-import sys
 
 import h5py
 import numpy as np
 import pandas as pd
 
-SRC = sys.argv[1]  # extracted outs dir
-OUT = sys.argv[2]  # output tiny_spaceranger dir
-DATASET_ID = sys.argv[3]  # feature_slice prefix / dataset id
-BINS = ["square_002um", "square_008um", "square_016um"]
-H5_FILES = ["filtered_feature_bc_matrix.h5", "raw_feature_bc_matrix.h5"]
-SPATIAL = [
-    "tissue_positions.parquet",
-    "scalefactors_json.json",
-    "tissue_hires_image.png",
-    "tissue_lowres_image.png",
-]
-TP_COLS = [
+# Bin sizes produced by Space Ranger HD, smallest to largest.
+BIN_DIRS = ["square_002um", "square_008um", "square_016um"]
+# The two count matrices kept for each bin size.
+MATRIX_FILES = ["filtered_feature_bc_matrix.h5", "raw_feature_bc_matrix.h5"]
+# Columns of tissue_positions.parquet, used to sanity-check the input.
+TISSUE_POSITION_COLUMNS = [
     "barcode",
     "in_tissue",
     "array_row",
@@ -34,131 +44,201 @@ TP_COLS = [
     "pxl_row_in_fullres",
     "pxl_col_in_fullres",
 ]
-W = 22
+# Side length (in 8 um bins) of the square region we crop to.
+WINDOW = 22
 
 
-def choose_bbox():
-    tp = pd.read_parquet(
-        f"{SRC}/binned_outputs/square_008um/spatial/tissue_positions.parquet"
+def find_crop_box(outs_dir):
+    """Find a tissue-straddling window on the 8 um grid.
+
+    Returns the full-resolution pixel bounding box (min/max row, min/max col) of
+    a ``WINDOW`` x ``WINDOW`` block of 8 um bins that mixes in-tissue and
+    background bins.
+    """
+    positions = pd.read_parquet(
+        f"{outs_dir}/binned_outputs/square_008um/spatial/tissue_positions.parquet"
     )
-    R, C = int(tp.array_row.max()) + 1, int(tp.array_col.max()) + 1
-    in_t = np.zeros((R, C), np.int64)
-    exists = np.zeros((R, C), np.int64)
-    in_t[tp.array_row.values, tp.array_col.values] = tp.in_tissue.values == 1
-    exists[tp.array_row.values, tp.array_col.values] = 1
-    It, Iv = in_t.cumsum(0).cumsum(1), exists.cumsum(0).cumsum(1)
+    n_rows = int(positions.array_row.max()) + 1
+    n_cols = int(positions.array_col.max()) + 1
 
-    def winsum(integral, r0, c0):
-        r1, c1 = r0 + W - 1, c0 + W - 1
-        tot = integral[r1, c1]
-        tot -= integral[r0 - 1, c1] if r0 > 0 else 0
-        tot -= integral[r1, c0 - 1] if c0 > 0 else 0
-        tot += integral[r0 - 1, c0 - 1] if r0 > 0 and c0 > 0 else 0
-        return int(tot)
+    # Lay the bins out on their (row, col) grid: one grid marking in-tissue bins,
+    # one marking which grid cells have a bin at all.
+    in_tissue_grid = np.zeros((n_rows, n_cols), np.int64)
+    bin_present_grid = np.zeros((n_rows, n_cols), np.int64)
+    rows = positions.array_row.values
+    cols = positions.array_col.values
+    in_tissue_grid[rows, cols] = positions.in_tissue.values == 1
+    bin_present_grid[rows, cols] = 1
 
-    best = None
-    for r0 in range(0, R - W, 2):
-        for c0 in range(0, C - W, 2):
-            v = winsum(Iv, r0, c0)
-            if v < W * W:
-                continue
-            t = winsum(It, r0, c0)
-            frac = t / v
-            if 0.45 <= frac <= 0.80 and t >= 150:
-                score = abs(frac - 0.6)
-                if best is None or score < best[0]:
-                    best = (score, r0, c0)
-    assert best is not None, "no mixed-tissue window found"
-    _, r0, c0 = best
-    blk = tp[
-        (tp.array_row >= r0)
-        & (tp.array_row < r0 + W)
-        & (tp.array_col >= c0)
-        & (tp.array_col < c0 + W)
+    # Summed-area tables: cumulative sums let us total any rectangular window in
+    # O(1) instead of re-summing its cells.
+    in_tissue_cumsum = in_tissue_grid.cumsum(0).cumsum(1)
+    bin_present_cumsum = bin_present_grid.cumsum(0).cumsum(1)
+
+    def window_total(cumsum, top, left):
+        """Sum of a WINDOW x WINDOW window with top-left corner at (top, left)."""
+        bottom, right = top + WINDOW - 1, left + WINDOW - 1
+        total = cumsum[bottom, right]
+        total -= cumsum[top - 1, right] if top > 0 else 0
+        total -= cumsum[bottom, left - 1] if left > 0 else 0
+        total += cumsum[top - 1, left - 1] if top > 0 and left > 0 else 0
+        return int(total)
+
+    # Scan windows (stride 2 for speed) and pick the one whose in-tissue fraction
+    # is closest to 0.6 -- a balanced mix of tissue and background.
+    best = None  # (distance_from_0.6, top, left)
+    for top in range(0, n_rows - WINDOW, 2):
+        for left in range(0, n_cols - WINDOW, 2):
+            n_bins = window_total(bin_present_cumsum, top, left)
+            if n_bins < WINDOW * WINDOW:
+                continue  # window must be fully populated with bins
+            n_in_tissue = window_total(in_tissue_cumsum, top, left)
+            tissue_fraction = n_in_tissue / n_bins
+            if 0.45 <= tissue_fraction <= 0.80 and n_in_tissue >= 150:
+                distance = abs(tissue_fraction - 0.6)
+                if best is None or distance < best[0]:
+                    best = (distance, top, left)
+    assert best is not None, "no tissue-straddling window found"
+
+    _, top, left = best
+    window_bins = positions[
+        (positions.array_row >= top)
+        & (positions.array_row < top + WINDOW)
+        & (positions.array_col >= left)
+        & (positions.array_col < left + WINDOW)
     ]
     print(
-        f"  8um window at row[{r0},{r0 + W}) col[{c0},{c0 + W}): "
-        f"{len(blk)} bins, {int(blk.in_tissue.sum())} in-tissue"
+        f"  8um window at row[{top},{top + WINDOW}) col[{left},{left + WINDOW}): "
+        f"{len(window_bins)} bins, {int(window_bins.in_tissue.sum())} in-tissue"
     )
     return (
-        blk.pxl_row_in_fullres.min(),
-        blk.pxl_row_in_fullres.max(),
-        blk.pxl_col_in_fullres.min(),
-        blk.pxl_col_in_fullres.max(),
+        window_bins.pxl_row_in_fullres.min(),
+        window_bins.pxl_row_in_fullres.max(),
+        window_bins.pxl_col_in_fullres.min(),
+        window_bins.pxl_col_in_fullres.max(),
     )
 
 
-def subset_h5(src, dst, keep):
-    with h5py.File(src, "r") as f:
-        bc = f["matrix/barcodes"][:]
-        cols = np.flatnonzero(np.isin(bc, list(keep)))
-        indptr = f["matrix/indptr"][:]
-        spans = [(int(indptr[j]), int(indptr[j + 1])) for j in cols]
-        points = (
-            np.concatenate([np.arange(s, e) for s, e in spans])
-            if spans
-            else np.array([], dtype=indptr.dtype)
-        )
-        new_indptr = np.zeros(len(cols) + 1, indptr.dtype)
-        if spans:
-            new_indptr[1:] = np.cumsum([e - s for s, e in spans])
-        n_feat = int(f["matrix/shape"][0])
-        with h5py.File(dst, "w") as g:
-            for k, v in f.attrs.items():
-                g.attrs[k] = v
-            m = g.create_group("matrix")
-            for k, v in f["matrix"].attrs.items():
-                m.attrs[k] = v
-            m.create_dataset("barcodes", data=bc[cols], compression="gzip")
-            m.create_dataset("data", data=f["matrix/data"][points], compression="gzip")
-            m.create_dataset(
-                "indices", data=f["matrix/indices"][points], compression="gzip"
+def subset_matrix(src_path, dst_path, keep_barcodes):
+    """Write a copy of a 10x feature-barcode matrix keeping only some barcodes.
+
+    The matrix is stored as CSC (one column per barcode), so subsetting barcodes
+    means selecting columns: gather each kept column's value range from ``indptr``
+    and rebuild the ``data`` / ``indices`` / ``indptr`` arrays. Returns the number
+    of barcodes kept.
+    """
+    with h5py.File(src_path, "r") as src:
+        barcodes = src["matrix/barcodes"][:]
+        kept_columns = np.flatnonzero(np.isin(barcodes, list(keep_barcodes)))
+        indptr = src["matrix/indptr"][:]
+
+        # Each kept column occupies indptr[col]:indptr[col + 1] in data/indices.
+        column_ranges = [(int(indptr[c]), int(indptr[c + 1])) for c in kept_columns]
+        if column_ranges:
+            kept_value_indices = np.concatenate(
+                [np.arange(start, end) for start, end in column_ranges]
             )
-            m.create_dataset("indptr", data=new_indptr, compression="gzip")
-            m.create_dataset("shape", data=np.array([n_feat, len(cols)], np.int32))
-            f.copy(f["matrix/features"], m, name="features")
-    return len(cols)
+        else:
+            kept_value_indices = np.array([], dtype=indptr.dtype)
+
+        new_indptr = np.zeros(len(kept_columns) + 1, indptr.dtype)
+        if column_ranges:
+            new_indptr[1:] = np.cumsum([end - start for start, end in column_ranges])
+
+        n_features = int(src["matrix/shape"][0])
+        with h5py.File(dst_path, "w") as dst:
+            for key, value in src.attrs.items():
+                dst.attrs[key] = value
+            matrix = dst.create_group("matrix")
+            for key, value in src["matrix"].attrs.items():
+                matrix.attrs[key] = value
+            matrix.create_dataset(
+                "barcodes", data=barcodes[kept_columns], compression="gzip"
+            )
+            matrix.create_dataset(
+                "data", data=src["matrix/data"][kept_value_indices], compression="gzip"
+            )
+            matrix.create_dataset(
+                "indices",
+                data=src["matrix/indices"][kept_value_indices],
+                compression="gzip",
+            )
+            matrix.create_dataset("indptr", data=new_indptr, compression="gzip")
+            matrix.create_dataset(
+                "shape", data=np.array([n_features, len(kept_columns)], np.int32)
+            )
+            src.copy(src["matrix/features"], matrix, name="features")
+    return len(kept_columns)
+
+
+def stub_feature_slice(src_path, dst_path):
+    """Copy only the root attributes of feature_slice.h5 (drop the heavy data)."""
+    with h5py.File(src_path, "r") as src, h5py.File(dst_path, "w") as dst:
+        for key, value in src.attrs.items():
+            dst.attrs[key] = value
 
 
 def main():
-    if os.path.exists(OUT):
-        shutil.rmtree(OUT)
-    os.makedirs(OUT)
-    # feature_slice stub at top level
-    with (
-        h5py.File(f"{SRC}/feature_slice.h5", "r") as s,
-        h5py.File(f"{OUT}/{DATASET_ID}_feature_slice.h5", "w") as d,
-    ):
-        for k, v in s.attrs.items():
-            d.attrs[k] = v
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="extracted Space Ranger outs dir")
+    parser.add_argument("--output", required=True, help="output tiny_spaceranger dir")
+    parser.add_argument(
+        "--dataset-id", required=True, help="feature_slice prefix / dataset id"
+    )
+    args = parser.parse_args()
+
+    if os.path.exists(args.output):
+        shutil.rmtree(args.output)
+    os.makedirs(args.output)
+
+    stub_feature_slice(
+        f"{args.input}/feature_slice.h5",
+        f"{args.output}/{args.dataset_id}_feature_slice.h5",
+    )
 
     print(">>> choosing crop region from 8um grid")
-    rmin, rmax, cmin, cmax = choose_bbox()
+    row_min, row_max, col_min, col_max = find_crop_box(args.input)
 
-    for b in BINS:
-        sdir, odir = f"{SRC}/binned_outputs/{b}", f"{OUT}/binned_outputs/{b}"
-        os.makedirs(f"{odir}/spatial")
-        tp = pd.read_parquet(f"{sdir}/spatial/tissue_positions.parquet")
-        assert list(tp.columns) == TP_COLS, list(tp.columns)
-        region = tp[
-            (tp.pxl_row_in_fullres >= rmin)
-            & (tp.pxl_row_in_fullres <= rmax)
-            & (tp.pxl_col_in_fullres >= cmin)
-            & (tp.pxl_col_in_fullres <= cmax)
+    for bin_dir in BIN_DIRS:
+        src_dir = f"{args.input}/binned_outputs/{bin_dir}"
+        out_dir = f"{args.output}/binned_outputs/{bin_dir}"
+        os.makedirs(f"{out_dir}/spatial")
+
+        positions = pd.read_parquet(f"{src_dir}/spatial/tissue_positions.parquet")
+        assert list(positions.columns) == TISSUE_POSITION_COLUMNS, list(positions.columns)
+        region = positions[
+            (positions.pxl_row_in_fullres >= row_min)
+            & (positions.pxl_row_in_fullres <= row_max)
+            & (positions.pxl_col_in_fullres >= col_min)
+            & (positions.pxl_col_in_fullres <= col_max)
         ].reset_index(drop=True)
-        region.to_parquet(f"{odir}/spatial/tissue_positions.parquet", index=False)
-        keep = {x.encode() if isinstance(x, str) else x for x in region.barcode}
-        nobs = {h: subset_h5(f"{sdir}/{h}", f"{odir}/{h}", keep) for h in H5_FILES}
-        # images + scalefactors kept as-is (coords align via unchanged scalefactor)
-        shutil.copy(f"{sdir}/spatial/scalefactors_json.json", f"{odir}/spatial/")
-        shutil.copy(f"{sdir}/spatial/tissue_hires_image.png", f"{odir}/spatial/")
-        shutil.copy(f"{sdir}/spatial/tissue_lowres_image.png", f"{odir}/spatial/")
+        region.to_parquet(f"{out_dir}/spatial/tissue_positions.parquet", index=False)
+
+        # Barcodes are stored as bytes in the matrix h5, so encode the strings.
+        keep_barcodes = {
+            bc.encode() if isinstance(bc, str) else bc for bc in region.barcode
+        }
+        n_kept = {
+            matrix_file: subset_matrix(
+                f"{src_dir}/{matrix_file}", f"{out_dir}/{matrix_file}", keep_barcodes
+            )
+            for matrix_file in MATRIX_FILES
+        }
+
+        # Images and scale factors are copied unchanged; bin coordinates still
+        # map onto the full image via the unchanged scale factor.
+        for spatial_file in (
+            "scalefactors_json.json",
+            "tissue_hires_image.png",
+            "tissue_lowres_image.png",
+        ):
+            shutil.copy(f"{src_dir}/spatial/{spatial_file}", f"{out_dir}/spatial/")
+
         print(
-            f"  {b}: region {len(region)} bins | "
-            f"filtered={nobs['filtered_feature_bc_matrix.h5']} "
-            f"raw={nobs['raw_feature_bc_matrix.h5']}"
+            f"  {bin_dir}: region {len(region)} bins | "
+            f"filtered={n_kept['filtered_feature_bc_matrix.h5']} "
+            f"raw={n_kept['raw_feature_bc_matrix.h5']}"
         )
-    os.system(f"du -sh {OUT}")
 
 
 if __name__ == "__main__":

--- a/resources_test_scripts/subset_visium_hd.py
+++ b/resources_test_scripts/subset_visium_hd.py
@@ -1,0 +1,131 @@
+"""Crop a Visium HD SpaceRanger `outs` to a tiny tissue-straddling region.
+
+Picks a contiguous WxW window of 8um bins that mixes in/out of tissue (so raw
+keeps more bins than filtered), then applies that fullres pixel bbox to every
+bin size, column-subsetting the count matrices to the region's barcodes.
+feature_slice.h5 is reduced to an attrs-only stub (the reader only needs its
+metadata_json). Images are kept as-is (coords stay aligned via the unchanged
+scalefactor)."""
+import json
+import os
+import shutil
+import sys
+
+import h5py
+import numpy as np
+import pandas as pd
+
+SRC = sys.argv[1]          # extracted outs dir
+OUT = sys.argv[2]          # output tiny_spaceranger dir
+DATASET_ID = sys.argv[3]   # feature_slice prefix / dataset id
+BINS = ["square_002um", "square_008um", "square_016um"]
+H5_FILES = ["filtered_feature_bc_matrix.h5", "raw_feature_bc_matrix.h5"]
+SPATIAL = ["tissue_positions.parquet", "scalefactors_json.json",
+           "tissue_hires_image.png", "tissue_lowres_image.png"]
+TP_COLS = ["barcode", "in_tissue", "array_row", "array_col",
+           "pxl_row_in_fullres", "pxl_col_in_fullres"]
+W = 22
+
+
+def choose_bbox():
+    tp = pd.read_parquet(f"{SRC}/binned_outputs/square_008um/spatial/tissue_positions.parquet")
+    R, C = int(tp.array_row.max()) + 1, int(tp.array_col.max()) + 1
+    in_t = np.zeros((R, C), np.int64)
+    exists = np.zeros((R, C), np.int64)
+    in_t[tp.array_row.values, tp.array_col.values] = (tp.in_tissue.values == 1)
+    exists[tp.array_row.values, tp.array_col.values] = 1
+    It, Iv = in_t.cumsum(0).cumsum(1), exists.cumsum(0).cumsum(1)
+
+    def winsum(I, r0, c0):
+        r1, c1 = r0 + W - 1, c0 + W - 1
+        tot = I[r1, c1]
+        tot -= I[r0 - 1, c1] if r0 > 0 else 0
+        tot -= I[r1, c0 - 1] if c0 > 0 else 0
+        tot += I[r0 - 1, c0 - 1] if r0 > 0 and c0 > 0 else 0
+        return int(tot)
+
+    best = None
+    for r0 in range(0, R - W, 2):
+        for c0 in range(0, C - W, 2):
+            v = winsum(Iv, r0, c0)
+            if v < W * W:
+                continue
+            t = winsum(It, r0, c0)
+            frac = t / v
+            if 0.45 <= frac <= 0.80 and t >= 150:
+                score = abs(frac - 0.6)
+                if best is None or score < best[0]:
+                    best = (score, r0, c0)
+    assert best is not None, "no mixed-tissue window found"
+    _, r0, c0 = best
+    blk = tp[(tp.array_row >= r0) & (tp.array_row < r0 + W) &
+             (tp.array_col >= c0) & (tp.array_col < c0 + W)]
+    print(f"  8um window at row[{r0},{r0+W}) col[{c0},{c0+W}): "
+          f"{len(blk)} bins, {int(blk.in_tissue.sum())} in-tissue")
+    return (blk.pxl_row_in_fullres.min(), blk.pxl_row_in_fullres.max(),
+            blk.pxl_col_in_fullres.min(), blk.pxl_col_in_fullres.max())
+
+
+def subset_h5(src, dst, keep):
+    with h5py.File(src, "r") as f:
+        bc = f["matrix/barcodes"][:]
+        cols = np.flatnonzero(np.isin(bc, list(keep)))
+        indptr = f["matrix/indptr"][:]
+        spans = [(int(indptr[j]), int(indptr[j + 1])) for j in cols]
+        points = (np.concatenate([np.arange(s, e) for s, e in spans])
+                  if spans else np.array([], dtype=indptr.dtype))
+        new_indptr = np.zeros(len(cols) + 1, indptr.dtype)
+        if spans:
+            new_indptr[1:] = np.cumsum([e - s for s, e in spans])
+        n_feat = int(f["matrix/shape"][0])
+        with h5py.File(dst, "w") as g:
+            for k, v in f.attrs.items():
+                g.attrs[k] = v
+            m = g.create_group("matrix")
+            for k, v in f["matrix"].attrs.items():
+                m.attrs[k] = v
+            m.create_dataset("barcodes", data=bc[cols], compression="gzip")
+            m.create_dataset("data", data=f["matrix/data"][points], compression="gzip")
+            m.create_dataset("indices", data=f["matrix/indices"][points], compression="gzip")
+            m.create_dataset("indptr", data=new_indptr, compression="gzip")
+            m.create_dataset("shape", data=np.array([n_feat, len(cols)], np.int32))
+            f.copy(f["matrix/features"], m, name="features")
+    return len(cols)
+
+
+def main():
+    if os.path.exists(OUT):
+        shutil.rmtree(OUT)
+    os.makedirs(OUT)
+    # feature_slice stub at top level
+    with h5py.File(f"{SRC}/feature_slice.h5", "r") as s, \
+         h5py.File(f"{OUT}/{DATASET_ID}_feature_slice.h5", "w") as d:
+        for k, v in s.attrs.items():
+            d.attrs[k] = v
+
+    print(">>> choosing crop region from 8um grid")
+    rmin, rmax, cmin, cmax = choose_bbox()
+
+    for b in BINS:
+        sdir, odir = f"{SRC}/binned_outputs/{b}", f"{OUT}/binned_outputs/{b}"
+        os.makedirs(f"{odir}/spatial")
+        tp = pd.read_parquet(f"{sdir}/spatial/tissue_positions.parquet")
+        assert list(tp.columns) == TP_COLS, list(tp.columns)
+        region = tp[(tp.pxl_row_in_fullres >= rmin) & (tp.pxl_row_in_fullres <= rmax) &
+                    (tp.pxl_col_in_fullres >= cmin) & (tp.pxl_col_in_fullres <= cmax)
+                    ].reset_index(drop=True)
+        region.to_parquet(f"{odir}/spatial/tissue_positions.parquet", index=False)
+        keep = {x.encode() if isinstance(x, str) else x for x in region.barcode}
+        nobs = {h: subset_h5(f"{sdir}/{h}", f"{odir}/{h}", keep) for h in H5_FILES}
+        # images + scalefactors kept as-is (coords align via unchanged scalefactor)
+        shutil.copy(f"{sdir}/spatial/scalefactors_json.json", f"{odir}/spatial/")
+        shutil.copy(f"{sdir}/spatial/tissue_hires_image.png", f"{odir}/spatial/")
+        shutil.copy(f"{sdir}/spatial/tissue_lowres_image.png", f"{odir}/spatial/")
+        print(f"  {b}: region {len(region)} bins | "
+              f"filtered={nobs['filtered_feature_bc_matrix.h5']} "
+              f"raw={nobs['raw_feature_bc_matrix.h5']}")
+    os.system(f"du -sh {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/resources_test_scripts/visium_hd_tiny.sh
+++ b/resources_test_scripts/visium_hd_tiny.sh
@@ -2,12 +2,14 @@
 
 set -eo pipefail
 
-# Visium HD tiny test fixture, cropped from the official 10x "Visium HD Tiny
-# 3prime Mouse Brain" developer dataset (Space Ranger 4.0.1). That dataset is
-# downsampled in reads and image, but its bin grid still spans the whole slide
-# (millions of 2 um bins), so it is cropped to one small tissue-straddling region
-# (see subset_visium_hd.py). Source:
-# https://www.10xgenomics.com/support/software/space-ranger/latest/resources/visium-hd-example-data
+# Visium HD tiny test fixture.
+#  * The cropped SpaceRanger outs come from the official 10x "Visium HD Tiny
+#    3prime Mouse Brain" developer dataset (subset_visium_hd.py crops it to a
+#    small tissue-straddling region, since its bin grid spans the whole slide).
+#  * The raw FASTQs and microscope image — needed to test the ingestion workflow
+#    end to end — are subset from the full "Visium HD 3prime Mouse Brain" dataset
+#    (the same sample), mirroring visium_tiny.sh.
+# Source: https://www.10xgenomics.com/datasets
 
 # get the root of the directory
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -15,9 +17,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 DIR="$REPO_ROOT/resources_test/visium_hd"
 ID="Visium_HD_Mouse_Brain"
-URL="https://cf.10xgenomics.com/samples/spatial-exp/4.0.1/Visium_HD_Tiny_3prime_Dataset/Visium_HD_Tiny_3prime_Dataset_outs.zip"
+TINY_OUTS_URL="https://cf.10xgenomics.com/samples/spatial-exp/4.0.1/Visium_HD_Tiny_3prime_Dataset/Visium_HD_Tiny_3prime_Dataset_outs.zip"
+FULL_BASE="https://cf.10xgenomics.com/samples/spatial-exp/4.0.1/Visium_HD_3prime_Mouse_Brain"
 
-# create tempdir for the (large) public outs zip
+# create tempdir for the (large) public downloads
 MY_TEMP="${VIASH_TEMP:-/tmp}"
 TMPDIR=$(mktemp -d "$MY_TEMP/visium_hd_tiny-XXXXXX")
 function clean_up {
@@ -27,15 +30,27 @@ trap clean_up EXIT
 
 mkdir -p "$DIR"
 
-# download and extract the official tiny SpaceRanger outs
-curl -fSL -o "$TMPDIR/outs.zip" "$URL"
+# 1. cropped SpaceRanger outs from the official tiny dataset
+curl -fSL -o "$TMPDIR/outs.zip" "$TINY_OUTS_URL"
 unzip -q "$TMPDIR/outs.zip" -d "$TMPDIR/outs"
-
-# crop to a tiny tissue-straddling region across all bin sizes
 python3 "$SCRIPT_DIR/subset_visium_hd.py" \
     "$TMPDIR/outs" \
     "$DIR/${ID}_tiny_spaceranger" \
     "$ID"
+
+# 2. tiny FASTQ run folder (first 100,000 reads) from the full dataset
+curl -fSL -o "$TMPDIR/fastqs.tar" "$FULL_BASE/Visium_HD_3prime_Mouse_Brain_fastqs.tar"
+mkdir -p "$TMPDIR/fastqs" "$DIR/${ID}_tiny"
+tar -xf "$TMPDIR/fastqs.tar" -C "$TMPDIR/fastqs"
+for r in R1 R2; do
+  src=$(find "$TMPDIR/fastqs" -name "*_L001_${r}_001.fastq.gz" | sort | head -1)
+  gzip -cdf "$src" | head -n 400000 | gzip -c \
+    > "$DIR/${ID}_tiny/${ID}_S1_L001_${r}_001.fastq.gz"
+done
+
+# 3. downsized microscope image from the full dataset
+curl -fSL -o "$TMPDIR/image.tif" "$FULL_BASE/Visium_HD_3prime_Mouse_Brain_image.tif"
+convert "$TMPDIR/image.tif" -resize 2000x2000 "$DIR/${ID}_image_tiny.jpg"
 
 # Sync to S3 (dry-run; drop --dryrun to upload)
 aws s3 sync \

--- a/resources_test_scripts/visium_hd_tiny.sh
+++ b/resources_test_scripts/visium_hd_tiny.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Visium HD tiny test fixture, cropped from the official 10x "Visium HD Tiny
+# 3prime Mouse Brain" developer dataset (Space Ranger 4.0.1). That dataset is
+# downsampled in reads and image, but its bin grid still spans the whole slide
+# (millions of 2 um bins), so it is cropped to one small tissue-straddling region
+# (see subset_visium_hd.py). Source:
+# https://www.10xgenomics.com/support/software/space-ranger/latest/resources/visium-hd-example-data
+
+# get the root of the directory
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DIR="$REPO_ROOT/resources_test/visium_hd"
+ID="Visium_HD_Mouse_Brain"
+URL="https://cf.10xgenomics.com/samples/spatial-exp/4.0.1/Visium_HD_Tiny_3prime_Dataset/Visium_HD_Tiny_3prime_Dataset_outs.zip"
+
+# create tempdir for the (large) public outs zip
+MY_TEMP="${VIASH_TEMP:-/tmp}"
+TMPDIR=$(mktemp -d "$MY_TEMP/visium_hd_tiny-XXXXXX")
+function clean_up {
+  [[ -d "$TMPDIR" ]] && rm -r "$TMPDIR"
+}
+trap clean_up EXIT
+
+mkdir -p "$DIR"
+
+# download and extract the official tiny SpaceRanger outs
+curl -fSL -o "$TMPDIR/outs.zip" "$URL"
+unzip -q "$TMPDIR/outs.zip" -d "$TMPDIR/outs"
+
+# crop to a tiny tissue-straddling region across all bin sizes
+python3 "$SCRIPT_DIR/subset_visium_hd.py" \
+    "$TMPDIR/outs" \
+    "$DIR/${ID}_tiny_spaceranger" \
+    "$ID"
+
+# Sync to S3 (dry-run; drop --dryrun to upload)
+aws s3 sync \
+    --profile di \
+    "$DIR" \
+    s3://openpipelines-bio/openpipeline_spatial/resources_test/visium_hd \
+    --delete \
+    --dryrun

--- a/resources_test_scripts/visium_hd_tiny.sh
+++ b/resources_test_scripts/visium_hd_tiny.sh
@@ -38,13 +38,15 @@ python3 "$SCRIPT_DIR/subset_visium_hd.py" \
     "$DIR/${ID}_tiny_spaceranger" \
     "$ID"
 
-# 2. tiny FASTQ run folder (first 100,000 reads) from the full dataset
+# 2. tiny FASTQ run folder (first 10,000 reads) from the full dataset. The full
+#    tar has no L001 (lanes are L002-L008), so take the first R1/R2 lane and
+#    write them under a canonical single-lane name.
 curl -fSL -o "$TMPDIR/fastqs.tar" "$FULL_BASE/Visium_HD_3prime_Mouse_Brain_fastqs.tar"
 mkdir -p "$TMPDIR/fastqs" "$DIR/${ID}_tiny"
 tar -xf "$TMPDIR/fastqs.tar" -C "$TMPDIR/fastqs"
 for r in R1 R2; do
-  src=$(find "$TMPDIR/fastqs" -name "*_L001_${r}_001.fastq.gz" | sort | head -1)
-  gzip -cdf "$src" | head -n 400000 | gzip -c \
+  src=$(find "$TMPDIR/fastqs" -name "*_${r}_*.fastq.gz" | sort | head -1)
+  gzip -cdf "$src" | head -n 40000 | gzip -c \
     > "$DIR/${ID}_tiny/${ID}_S1_L001_${r}_001.fastq.gz"
 done
 

--- a/resources_test_scripts/visium_hd_tiny.sh
+++ b/resources_test_scripts/visium_hd_tiny.sh
@@ -2,13 +2,13 @@
 
 set -eo pipefail
 
-# Visium HD tiny test fixture.
-#  * The cropped SpaceRanger outs come from the official 10x "Visium HD Tiny
-#    3prime Mouse Brain" developer dataset (subset_visium_hd.py crops it to a
-#    small tissue-straddling region, since its bin grid spans the whole slide).
-#  * The raw FASTQs and microscope image — needed to test the ingestion workflow
-#    end to end — are subset from the full "Visium HD 3prime Mouse Brain" dataset
-#    (the same sample), mirroring visium_tiny.sh.
+# Visium HD tiny test fixture, all derived from the official 10x "Visium HD Tiny
+# 3prime Mouse Brain" developer dataset (a downsampled corner of the tissue):
+#  * the cropped SpaceRanger outs (subset_visium_hd.py crops them further to a
+#    small tissue-straddling region, since the bin grid spans the whole slide);
+#  * the raw FASTQs, reconstructed from the outs BAM with 10x bamtofastq, so they
+#    are consistent with the outs and let the ingestion workflow run Space Ranger;
+#  * the microscope image, from the full "Visium HD 3prime Mouse Brain" dataset.
 # Source: https://www.10xgenomics.com/datasets
 
 # get the root of the directory
@@ -19,6 +19,7 @@ DIR="$REPO_ROOT/resources_test/visium_hd"
 ID="Visium_HD_Mouse_Brain"
 TINY_OUTS_URL="https://cf.10xgenomics.com/samples/spatial-exp/4.0.1/Visium_HD_Tiny_3prime_Dataset/Visium_HD_Tiny_3prime_Dataset_outs.zip"
 FULL_BASE="https://cf.10xgenomics.com/samples/spatial-exp/4.0.1/Visium_HD_3prime_Mouse_Brain"
+BAMTOFASTQ_VERSION="1.4.1"
 
 # create tempdir for the (large) public downloads
 MY_TEMP="${VIASH_TEMP:-/tmp}"
@@ -38,16 +39,22 @@ python3 "$SCRIPT_DIR/subset_visium_hd.py" \
     --output "$DIR/${ID}_tiny_spaceranger" \
     --dataset-id "$ID"
 
-# 2. tiny FASTQ run folder (first 10,000 reads) from the full dataset. The full
-#    tar has no L001 (lanes are L002-L008), so take the first R1/R2 lane and
-#    write them under a canonical single-lane name.
-curl -fSL -o "$TMPDIR/fastqs.tar" "$FULL_BASE/Visium_HD_3prime_Mouse_Brain_fastqs.tar"
-mkdir -p "$TMPDIR/fastqs" "$DIR/${ID}_tiny"
-tar -xf "$TMPDIR/fastqs.tar" -C "$TMPDIR/fastqs"
+# 2. tiny FASTQ run folder, reconstructed from the cropped corner's BAM with 10x
+#    bamtofastq. This keeps the reads consistent with the SpaceRanger outs above
+#    and avoids downloading the full (~12 GB) FASTQ tar.
+case "$(uname -s)" in
+  Darwin) bamtofastq_asset="bamtofastq_macos" ;;
+  *) bamtofastq_asset="bamtofastq_linux" ;;
+esac
+curl -fSL -o "$TMPDIR/bamtofastq" \
+  "https://github.com/10XGenomics/bamtofastq/releases/download/v${BAMTOFASTQ_VERSION}/${bamtofastq_asset}"
+chmod +x "$TMPDIR/bamtofastq"
+"$TMPDIR/bamtofastq" --nthreads=4 \
+  "$TMPDIR/outs/possorted_genome_bam.bam" "$TMPDIR/bamfq"
+mkdir -p "$DIR/${ID}_tiny"
 for r in R1 R2; do
-  src=$(find "$TMPDIR/fastqs" -name "*_${r}_*.fastq.gz" | sort | head -1)
-  gzip -cdf "$src" | head -n 40000 | gzip -c \
-    > "$DIR/${ID}_tiny/${ID}_S1_L001_${r}_001.fastq.gz"
+  src=$(find "$TMPDIR/bamfq" -name "*_${r}_001.fastq.gz" | sort | head -1)
+  cp "$src" "$DIR/${ID}_tiny/${ID}_S1_L001_${r}_001.fastq.gz"
 done
 
 # 3. downsized microscope image from the full dataset

--- a/resources_test_scripts/visium_hd_tiny.sh
+++ b/resources_test_scripts/visium_hd_tiny.sh
@@ -34,9 +34,9 @@ mkdir -p "$DIR"
 curl -fSL -o "$TMPDIR/outs.zip" "$TINY_OUTS_URL"
 unzip -q "$TMPDIR/outs.zip" -d "$TMPDIR/outs"
 python3 "$SCRIPT_DIR/subset_visium_hd.py" \
-    "$TMPDIR/outs" \
-    "$DIR/${ID}_tiny_spaceranger" \
-    "$ID"
+    --input "$TMPDIR/outs" \
+    --output "$DIR/${ID}_tiny_spaceranger" \
+    --dataset-id "$ID"
 
 # 2. tiny FASTQ run folder (first 10,000 reads) from the full dataset. The full
 #    tar has no L001 (lanes are L002-L008), so take the first R1/R2 lane and


### PR DESCRIPTION
Adds `resources_test_scripts/visium_hd_tiny.sh` (+ `subset_visium_hd.py`) that builds the tiny Visium HD fixture by cropping the official 10x "Visium HD Tiny 3prime Mouse Brain" SpaceRanger outs to a small tissue-straddling region (the dataset's bin grid spans the whole slide, so it must be cropped for CI).

Test plan:
- [x] Crop produces all 3 bin sizes (8um: 290 filtered / 484 raw), 9.6 MB total
- [x] `from_spaceranger_hd_to_spatialdata` (pfizer-spatial) passes 5/5 on the fixture
- [ ] S3 sync (run without --dryrun to upload)