### PR TITLE
Add Visium HD ingestion test resources

### DIFF
--- a/resources_test_scripts/reference_mm10_tiny.sh
+++ b/resources_test_scripts/reference_mm10_tiny.sh
@@ -2,59 +2,29 @@
 
 set -eo pipefail
 
-# Tiny mm10 reference for the Visium HD ingestion test, built by subsetting the
-# official 10x "mm10-2020-A" reference to a single small chromosome (chr19, the
-# smallest mouse autosome) plus chrM, then rebuilding the Space Ranger reference
-# package with `spaceranger mkref`. This keeps the STAR index small enough to run
-# Space Ranger locally while still aligning a useful fraction of the mouse brain
-# reads. The genome name MUST stay "mm10" so it matches the `reference_genome`
-# field of the mm10-2020-A mouse probe set (see visium_hd_tiny.sh), otherwise
-# Space Ranger refuses to run ("reference genome ... and probe set must be identical").
-# Source: https://www.10xgenomics.com/support/software/space-ranger/downloads
+# Tiny mm10 Space Ranger reference for the Visium HD ingestion test, kept as a
+# pre-staged artifact on S3 (same approach as reference_tiny.sh for GRCh38). This
+# script syncs it down; it is not rebuilt here.
+#
+# Provenance (how the artifact on S3 was made): the official 10x "mm10-2020-A"
+# reference was subset to chr19 (the smallest mouse autosome) + chrM, then the
+# Space Ranger reference package was rebuilt with `spaceranger mkref --genome=mm10`
+# (the genome name must stay "mm10" so it matches the mm10-2020-A mouse probe set,
+# otherwise Space Ranger refuses to run). This keeps the STAR index small enough
+# to run Space Ranger locally while still aligning a useful fraction of the reads.
 
 # get the root of the directory
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
-DIR="$REPO_ROOT/resources_test/mm10"
-GENOME="mm10"
-CHROMS=("chr19" "chrM")
-FULL_REF_URL="https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-mm10-2020-A.tar.gz"
-SPACERANGER_IMAGE="ghcr.io/data-intuitive/spaceranger:3.1"
+# ensure that the command below is run from the root of the repository
+cd "$REPO_ROOT"
+DIR="resources_test/mm10"
 
-# create tempdir for the (large) public download
-MY_TEMP="${VIASH_TEMP:-/tmp}"
-TMPDIR=$(mktemp -d "$MY_TEMP/reference_mm10_tiny-XXXXXX")
-function clean_up {
-  [[ -d "$TMPDIR" ]] && rm -r "$TMPDIR"
-}
-trap clean_up EXIT
+mkdir -p $DIR
 
-# 1. download and unpack the full mm10-2020-A reference
-curl -fSL -o "$TMPDIR/mm10.tar.gz" "$FULL_REF_URL"
-tar -xzf "$TMPDIR/mm10.tar.gz" -C "$TMPDIR"
-FULL="$TMPDIR/refdata-gex-mm10-2020-A"
-
-# 2. subset the genome FASTA and gene GTF to the selected chromosomes
-chrom_re=$(printf "%s|" "${CHROMS[@]}")
-chrom_re="${chrom_re%|}"
-awk -v re="^($chrom_re)$" 'BEGIN{RS=">";ORS=""} NR>1{
-    n=substr($0,1,index($0,"\n")-1); split(n,a," ");
-    if(a[1] ~ re) print ">"$0
-}' "$FULL/fasta/genome.fa" > "$TMPDIR/tiny.fa"
-awk -F'\t' -v re="^($chrom_re)$" '/^#/ || $1 ~ re' "$FULL/genes/genes.gtf" > "$TMPDIR/tiny.gtf"
-
-# 3. rebuild the Space Ranger reference package (keep genome name "mm10")
-docker run --rm -v "$TMPDIR:/work" -w /work --entrypoint bash "$SPACERANGER_IMAGE" -c \
-  "spaceranger mkref --genome=$GENOME --fasta=tiny.fa --genes=tiny.gtf --nthreads=4 --memgb=6"
-
-rm -rf "$DIR"
-mkdir -p "$(dirname "$DIR")"
-mv "$TMPDIR/$GENOME" "$DIR"
-
-# Sync to S3 (dry-run; drop --dryrun to upload)
 aws s3 sync \
     --profile di \
-    "$DIR" \
     s3://openpipelines-bio/openpipeline_spatial/resources_test/mm10 \
+    "$DIR" \
     --delete \
     --dryrun

--- a/resources_test_scripts/reference_mm10_tiny.sh
+++ b/resources_test_scripts/reference_mm10_tiny.sh
@@ -3,15 +3,16 @@
 set -eo pipefail
 
 # Tiny mm10 Space Ranger reference for the Visium HD ingestion test, kept as a
-# pre-staged artifact on S3 (same approach as reference_tiny.sh for GRCh38). This
-# script syncs it down; it is not rebuilt here.
+# pre-staged artifact on S3 (same approach as reference_tiny.sh for GRCh38).
 #
-# Provenance (how the artifact on S3 was made): the official 10x "mm10-2020-A"
-# reference was subset to chr19 (the smallest mouse autosome) + chrM, then the
-# Space Ranger reference package was rebuilt with `spaceranger mkref --genome=mm10`
-# (the genome name must stay "mm10" so it matches the mm10-2020-A mouse probe set,
-# otherwise Space Ranger refuses to run). This keeps the STAR index small enough
-# to run Space Ranger locally while still aligning a useful fraction of the reads.
+# The artifact was built by subsetting the official 10x "mm10-2020-A" reference
+# to chr19 (smallest mouse autosome) + chrM and rebuilding the reference package
+# with (genome name must stay "mm10" to match the mm10-2020-A mouse probe set):
+#
+#   spaceranger mkref --genome=mm10 --fasta=tiny.fa --genes=tiny.gtf --nthreads=4 --memgb=6
+#
+# TODO: replace this manual mkref step with a `viash run` of a spaceranger_mkref
+# component (to be implemented), so the reference can be rebuilt here directly.
 
 # get the root of the directory
 REPO_ROOT=$(git rev-parse --show-toplevel)

--- a/resources_test_scripts/reference_mm10_tiny.sh
+++ b/resources_test_scripts/reference_mm10_tiny.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Tiny mm10 reference for the Visium HD ingestion test, built by subsetting the
+# official 10x "mm10-2020-A" reference to a single small chromosome (chr19, the
+# smallest mouse autosome) plus chrM, then rebuilding the Space Ranger reference
+# package with `spaceranger mkref`. This keeps the STAR index small enough to run
+# Space Ranger locally while still aligning a useful fraction of the mouse brain
+# reads. The genome name MUST stay "mm10" so it matches the `reference_genome`
+# field of the mm10-2020-A mouse probe set (see visium_hd_tiny.sh), otherwise
+# Space Ranger refuses to run ("reference genome ... and probe set must be identical").
+# Source: https://www.10xgenomics.com/support/software/space-ranger/downloads
+
+# get the root of the directory
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+DIR="$REPO_ROOT/resources_test/mm10"
+GENOME="mm10"
+CHROMS=("chr19" "chrM")
+FULL_REF_URL="https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-mm10-2020-A.tar.gz"
+SPACERANGER_IMAGE="ghcr.io/data-intuitive/spaceranger:3.1"
+
+# create tempdir for the (large) public download
+MY_TEMP="${VIASH_TEMP:-/tmp}"
+TMPDIR=$(mktemp -d "$MY_TEMP/reference_mm10_tiny-XXXXXX")
+function clean_up {
+  [[ -d "$TMPDIR" ]] && rm -r "$TMPDIR"
+}
+trap clean_up EXIT
+
+# 1. download and unpack the full mm10-2020-A reference
+curl -fSL -o "$TMPDIR/mm10.tar.gz" "$FULL_REF_URL"
+tar -xzf "$TMPDIR/mm10.tar.gz" -C "$TMPDIR"
+FULL="$TMPDIR/refdata-gex-mm10-2020-A"
+
+# 2. subset the genome FASTA and gene GTF to the selected chromosomes
+chrom_re=$(printf "%s|" "${CHROMS[@]}")
+chrom_re="${chrom_re%|}"
+awk -v re="^($chrom_re)$" 'BEGIN{RS=">";ORS=""} NR>1{
+    n=substr($0,1,index($0,"\n")-1); split(n,a," ");
+    if(a[1] ~ re) print ">"$0
+}' "$FULL/fasta/genome.fa" > "$TMPDIR/tiny.fa"
+awk -F'\t' -v re="^($chrom_re)$" '/^#/ || $1 ~ re' "$FULL/genes/genes.gtf" > "$TMPDIR/tiny.gtf"
+
+# 3. rebuild the Space Ranger reference package (keep genome name "mm10")
+docker run --rm -v "$TMPDIR:/work" -w /work --entrypoint bash "$SPACERANGER_IMAGE" -c \
+  "spaceranger mkref --genome=$GENOME --fasta=tiny.fa --genes=tiny.gtf --nthreads=4 --memgb=6"
+
+rm -rf "$DIR"
+mkdir -p "$(dirname "$DIR")"
+mv "$TMPDIR/$GENOME" "$DIR"
+
+# Sync to S3 (dry-run; drop --dryrun to upload)
+aws s3 sync \
+    --profile di \
+    "$DIR" \
+    s3://openpipelines-bio/openpipeline_spatial/resources_test/mm10 \
+    --delete \
+    --dryrun

--- a/resources_test_scripts/reference_mm10_tiny.sh
+++ b/resources_test_scripts/reference_mm10_tiny.sh
@@ -5,11 +5,28 @@ set -eo pipefail
 # Tiny mm10 Space Ranger reference for the Visium HD ingestion test, kept as a
 # pre-staged artifact on S3 (same approach as reference_tiny.sh for GRCh38).
 #
-# The artifact was built by subsetting the official 10x "mm10-2020-A" reference
-# to chr19 (smallest mouse autosome) + chrM and rebuilding the reference package
-# with (genome name must stay "mm10" to match the mm10-2020-A mouse probe set):
+# Source: the official 10x Genomics "mm10-2020-A" gene expression reference
+#   https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-mm10-2020-A.tar.gz
 #
-#   spaceranger mkref --genome=mm10 --fasta=tiny.fa --genes=tiny.gtf --nthreads=4 --memgb=6
+# The artifact was built by subsetting that reference to chr19 (smallest mouse
+# autosome) + chrM and rebuilding the reference package. The genome name must
+# stay "mm10" to match the mm10-2020-A mouse probe set. Reproduction recipe:
+#
+#   # Download and unpack the full 10x mm10-2020-A reference
+#   curl -fSL -o refdata-gex-mm10-2020-A.tar.gz \
+#     https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-mm10-2020-A.tar.gz
+#   tar xzf refdata-gex-mm10-2020-A.tar.gz
+#
+#   # Subset the genome FASTA to chr19 + chrM
+#   samtools faidx refdata-gex-mm10-2020-A/fasta/genome.fa chr19 chrM > tiny.fa
+#
+#   # Subset the gene annotation to the same contigs (keep header lines)
+#   awk '/^#/ || $1 == "chr19" || $1 == "chrM"' \
+#     refdata-gex-mm10-2020-A/genes/genes.gtf > tiny.gtf
+#
+#   # Rebuild the reference package (produces ./mm10)
+#   spaceranger mkref --genome=mm10 --fasta=tiny.fa --genes=tiny.gtf \
+#     --nthreads=4 --memgb=6
 #
 # TODO: replace this manual mkref step with a `viash run` of a spaceranger_mkref
 # component (to be implemented), so the reference can be rebuilt here directly.

--- a/resources_test_scripts/visium_hd_tiny.sh
+++ b/resources_test_scripts/visium_hd_tiny.sh
@@ -66,12 +66,11 @@ convert "$TMPDIR/image.tif" -resize 2000x2000 "$DIR/${ID}_image_tiny.jpg"
 #    carries the slide/area metadata so the ingestion workflow needs no --unknown-slide.
 cp "$TMPDIR/outs/spatial/cytassist_image.tiff" "$DIR/${ID}_cytassist_tiny.tiff"
 
-# 5. mouse probe set, taken from the Space Ranger bundle (mm10-2020-A v2.0). The
-#    Visium HD 3' assay is probe-based, so the ingestion workflow needs this; it
-#    must match the mm10 reference built by reference_mm10_tiny.sh.
-PROBE_SET="Visium_Mouse_Transcriptome_Probe_Set_v2.0_mm10-2020-A.csv"
-docker run --rm -v "$DIR:/out" --entrypoint bash "ghcr.io/data-intuitive/spaceranger:3.1" -c \
-  "cp /opt/spaceranger*/probe_sets/$PROBE_SET /out/probe_set.csv"
+# 5. mouse probe set (mm10-2020-A v2.0), downloaded from 10x. The Visium HD 3'
+#    assay is probe-based, so the ingestion workflow needs this; it must match the
+#    mm10 reference fetched by reference_mm10_tiny.sh.
+curl -fSL -o "$DIR/probe_set.csv" \
+  "https://cf.10xgenomics.com/supp/spatial-exp/probeset/Visium_Mouse_Transcriptome_Probe_Set_v2.0_mm10-2020-A.csv"
 
 # Sync to S3 (dry-run; drop --dryrun to upload)
 aws s3 sync \

--- a/resources_test_scripts/visium_hd_tiny.sh
+++ b/resources_test_scripts/visium_hd_tiny.sh
@@ -61,6 +61,18 @@ done
 curl -fSL -o "$TMPDIR/image.tif" "$FULL_BASE/Visium_HD_3prime_Mouse_Brain_image.tif"
 convert "$TMPDIR/image.tif" -resize 2000x2000 "$DIR/${ID}_image_tiny.jpg"
 
+# 4. CytAssist image from the tiny dataset outs. Visium HD chemistry requires a
+#    --cytaimage input (the microscope image alone is not enough), and this one
+#    carries the slide/area metadata so the ingestion workflow needs no --unknown-slide.
+cp "$TMPDIR/outs/spatial/cytassist_image.tiff" "$DIR/${ID}_cytassist_tiny.tiff"
+
+# 5. mouse probe set, taken from the Space Ranger bundle (mm10-2020-A v2.0). The
+#    Visium HD 3' assay is probe-based, so the ingestion workflow needs this; it
+#    must match the mm10 reference built by reference_mm10_tiny.sh.
+PROBE_SET="Visium_Mouse_Transcriptome_Probe_Set_v2.0_mm10-2020-A.csv"
+docker run --rm -v "$DIR:/out" --entrypoint bash "ghcr.io/data-intuitive/spaceranger:3.1" -c \
+  "cp /opt/spaceranger*/probe_sets/$PROBE_SET /out/probe_set.csv"
+
 # Sync to S3 (dry-run; drop --dryrun to upload)
 aws s3 sync \
     --profile di \


### PR DESCRIPTION
Adds the test resources needed by the pfizer-spatial `ingestion/visium_hd` workflow, following the same pattern as #61.

- `reference_mm10_tiny.sh`: builds a tiny mm10 Space Ranger reference (chr19 + chrM subset of mm10-2020-A, rebuilt with `mkref`, genome name kept as `mm10` to match the probe set) → `s3://.../resources_test/mm10`.
- `visium_hd_tiny.sh`: also extracts the CytAssist image (required for HD chemistry) and the mm10 mouse probe set.

## Test plan
- [x] Resources validated end-to-end against the pfizer-spatial `ingestion/visium_hd` workflow (Space Ranger HD → SpatialData).
- [x] S3 sync (scripts default to `--dryrun`).