### PR TITLE
Install zipfile-inflate64 from PyPI instead of codeberg git clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ## BUG FIXES
 
-* `convert/from_xenium_to_h5mu`, `convert/from_xenium_to_spatialdata`, `convert/from_cosmx_to_h5mu`, `convert/from_cells2stats_to_h5mu`: Install `zipfile-inflate64` from PyPI instead of cloning it from codeberg.org, which fixes Docker build failures on infrastructure whose egress IP codeberg blocks (PR #PRNUM).
+* `convert/from_xenium_to_h5mu`, `convert/from_xenium_to_spatialdata`, `convert/from_cosmx_to_h5mu`, `convert/from_cells2stats_to_h5mu`: Install `zipfile-inflate64` from PyPI instead of cloning it from codeberg.org, which fixes Docker build failures on infrastructure whose egress IP codeberg blocks (PR #67).
 
 * `dataflow/concatenate_spatialdata`: Handle a single input and make sure regions are properly tracked with the appropriate `"spatialdata_attrs"` (PR #58) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ## BUG FIXES
 
+* `convert/from_xenium_to_h5mu`, `convert/from_xenium_to_spatialdata`, `convert/from_cosmx_to_h5mu`, `convert/from_cells2stats_to_h5mu`: Install `zipfile-inflate64` from PyPI instead of cloning it from codeberg.org, which fixes Docker build failures on infrastructure whose egress IP codeberg blocks (PR #PRNUM).
+
 * `dataflow/concatenate_spatialdata`: Handle a single input and make sure regions are properly tracked with the appropriate `"spatialdata_attrs"` (PR #58) 
 
 # openpipeline_spatial 0.5.0

--- a/src/convert/from_cells2stats_to_h5mu/config.vsh.yaml
+++ b/src/convert/from_cells2stats_to_h5mu/config.vsh.yaml
@@ -119,10 +119,9 @@ engines:
           - git
       - type: python
         __merge__: [/src/base/requirements/anndata_mudata.yaml, .]
-        packages: [ pyarrow ]
         # Windows explorer uses DEFLATE64 compression for large ZIP files,
         # which is not supported by most standard library zipfile module
-        git: [ https://codeberg.org/miurahr/zipfile-inflate64.git@v0.2 ]
+        packages: [ pyarrow, zipfile-inflate64 ]
     test_setup:
       - type: apt
         packages:

--- a/src/convert/from_cosmx_to_h5mu/config.vsh.yaml
+++ b/src/convert/from_cosmx_to_h5mu/config.vsh.yaml
@@ -59,10 +59,9 @@ engines:
           - git
       - type: python
         __merge__: [/src/base/requirements/anndata_mudata.yaml, /src/base/requirements/squidpy.yaml, .]
-        packages: [ pyarrow ]
         # Windows explorer uses DEFLATE64 compression for large ZIP files,
         # which is not supported by most standard library zipfile module
-        git: [ https://codeberg.org/miurahr/zipfile-inflate64.git@v0.2 ]
+        packages: [ pyarrow, zipfile-inflate64 ]
     test_setup:
       - type: apt
         packages:

--- a/src/convert/from_xenium_to_h5mu/config.vsh.yaml
+++ b/src/convert/from_xenium_to_h5mu/config.vsh.yaml
@@ -61,10 +61,9 @@ engines:
           - git
       - type: python
         __merge__: [/src/base/requirements/anndata_mudata.yaml, /src/base/requirements/scanpy.yaml, .]
-        packages: [ pyarrow ]
         # Windows explorer uses DEFLATE64 compression for large ZIP files,
         # which is not supported by most standard library zipfile module
-        git: [ https://codeberg.org/miurahr/zipfile-inflate64.git@v0.2 ]
+        packages: [ pyarrow, zipfile-inflate64 ]
     test_setup:
       - type: apt
         packages:

--- a/src/convert/from_xenium_to_spatialdata/config.vsh.yaml
+++ b/src/convert/from_xenium_to_spatialdata/config.vsh.yaml
@@ -96,7 +96,7 @@ engines:
       - type: python
         # Windows explorer uses DEFLATE64 compression for large ZIP files,
         # which is not supported by most standard library zipfile module
-        git: [ https://codeberg.org/miurahr/zipfile-inflate64.git@v0.2 ]
+        packages: [ zipfile-inflate64 ]
         __merge__: [ /src/base/requirements/spatialdata-io.yaml, . ]
     test_setup:
       - type: apt


### PR DESCRIPTION
The four `convert/` components that ingest DEFLATE64 zip bundles installed `zipfile-inflate64` by cloning it from codeberg.org at Docker build time. Codeberg blocks many datacenter egress IP ranges, causing `403` build failures on vsh CI.

The package is published on PyPI (version `0.1`, code-identical to the pinned git `v0.2` — only docs/CI files differ between the tags), so this installs it from PyPI instead, removing codeberg from the build path entirely.

Affected components:
- `convert/from_xenium_to_h5mu`
- `convert/from_xenium_to_spatialdata`
- `convert/from_cosmx_to_h5mu`
- `convert/from_cells2stats_to_h5mu`