### PR TITLE
Fix HD integration test failing on 10x Cloud authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## BREAKING CHANGES
 
-* `mapping/spaceranger_count` and `workflows/ingestion/spaceranger_mapping`: Update Space Ranger from 3.1 to 4.1.0. `--probe_set` is now optional (omit for Visium HD 3' data), telemetry and the web UI are disabled for non-interactive runs, and new 4.x arguments are exposed for nucleus/cell segmentation (`--nucleus_segmentation`, `--custom_segmentation_file`, `--nucleus_expansion_distance_micron`, `--max_nucleus_diameter_px`), UMI-based registration (`--umi_registration`, `--umi_to_image_offset`), cell type annotation (`--cell_annotation_model`, `--tenx_cloud_token_path`, `--disable_cell_annotation`), and intron inclusion (`--include_introns`) (PR #64).
+* `mapping/spaceranger_count` and `workflows/ingestion/spaceranger_mapping`: Update Space Ranger from 3.1 to 4.1.0. `--probe_set` is now optional (omit for Visium HD 3' data), telemetry and the web UI are disabled for non-interactive runs, and new 4.x arguments are exposed for nucleus/cell segmentation (`--nucleus_segmentation`, `--custom_segmentation_file`, `--nucleus_expansion_distance_micron`, `--max_nucleus_diameter_px`), UMI-based registration (`--umi_registration`, `--umi_to_image_offset`), cell type annotation (`--cell_annotation_model`, `--tenx_cloud_token_path`, `--disable_cell_annotation`), and intron inclusion (`--include_introns`) (PR #64, PR #70).
 
 ## NEW FUNCTIONALITY
 

--- a/src/mapping/spaceranger_count/config.vsh.yaml
+++ b/src/mapping/spaceranger_count/config.vsh.yaml
@@ -237,7 +237,10 @@ argument_groups:
         name: --cell_annotation_model
         required: false
         description: |
-          Cell type annotation model to use (Visium HD / HD 3' only, requires segmentation).
+          Cloud-based cell type annotation model to use (Visium HD / HD 3' only, requires
+          segmentation), which requires --tenx_cloud_token_path. When left out, Space Ranger
+          still annotates human samples with the bundled Pan-Human Azimuth model, which runs
+          locally and needs no token.
         choices: [auto, human_pca_v1_beta, mouse_pca_v1_beta]
 
       - type: file

--- a/src/workflows/ingestion/spaceranger_hd_mapping/config.vsh.yaml
+++ b/src/workflows/ingestion/spaceranger_hd_mapping/config.vsh.yaml
@@ -211,9 +211,10 @@ argument_groups:
         type: string
         required: false
         description: |
-          Cell type annotation model to use. The Pan-Human Azimuth model
-          (`human_pca_v1_beta`) runs locally without a 10x Cloud token for human
-          samples.
+          Cloud-based cell type annotation model to use, which requires
+          `--tenx_cloud_token_path`. When left out, Space Ranger still annotates
+          human samples with the bundled Pan-Human Azimuth model, which runs
+          locally and needs no token.
         choices: [auto, human_pca_v1_beta, mouse_pca_v1_beta]
       - name: --tenx_cloud_token_path
         type: file

--- a/src/workflows/ingestion/spaceranger_hd_mapping/test.nf
+++ b/src/workflows/ingestion/spaceranger_hd_mapping/test.nf
@@ -27,9 +27,6 @@ workflow test_wf {
         slide: "H1-84QJZFR",
         area: "D1",
         create_bam: false,
-        // Human sample -> the bundled Pan-Human Azimuth model runs locally (no
-        // 10x Cloud token), so cell-type annotation is exercised end-to-end.
-        cell_annotation_model: "human_pca_v1_beta",
         output_type: "filtered",
       ]
     ])

--- a/src/workflows/ingestion/spaceranger_mapping/config.vsh.yaml
+++ b/src/workflows/ingestion/spaceranger_mapping/config.vsh.yaml
@@ -250,7 +250,10 @@ argument_groups:
         type: string
         required: false
         description: |
-          Cell type annotation model to use (Visium HD / HD 3' only, requires segmentation).
+          Cloud-based cell type annotation model to use (Visium HD / HD 3' only, requires
+          segmentation), which requires --tenx_cloud_token_path. When left out, Space Ranger
+          still annotates human samples with the bundled Pan-Human Azimuth model, which runs
+          locally and needs no token.
         choices: [auto, human_pca_v1_beta, mouse_pca_v1_beta]
       - name: --tenx_cloud_token_path
         type: file


### PR DESCRIPTION
The `spaceranger_hd_mapping` integration test failed Space Ranger preflight with `Failed to authenticate for Cell Ranger Cloud`.

`--cell_annotation_model` only ever selects a **10x Cloud** model, so both `human_pca_v1_beta` and `mouse_pca_v1_beta` require `--tenx_cloud_token_path`. Leaving the argument out is what runs the bundled Pan-Human Azimuth model locally, with no token. The test named `human_pca_v1_beta` on the assumption that it was the local model.

* Drop `cell_annotation_model` from the HD integration test, so annotation runs locally on this human sample and `spaceranger_hd_mapping_test` can still assert the `fine_cell_type` column.
* Correct the `--cell_annotation_model` description in `mapping/spaceranger_count`, `workflows/ingestion/spaceranger_mapping` and `workflows/ingestion/spaceranger_hd_mapping`.