### PR TITLE
Pin `anndata` in `spatialdata` environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 * Bump `spatialdata` to version 0.8.0 and `ome-zarr` to 0.18.0 (PR #65).
 
+* Pin `anndata` in `spatialdata` environments to the same version used by other environments (PR #71).
+
 ## BUG FIXES
 
 * `convert/from_xenium_to_h5mu`, `convert/from_xenium_to_spatialdata`, `convert/from_cosmx_to_h5mu`, `convert/from_cells2stats_to_h5mu`: Install `zipfile-inflate64` from PyPI instead of cloning it from codeberg.org, which fixes Docker build failures on infrastructure whose egress IP codeberg blocks (PR #67).

--- a/src/base/requirements/spatialdata.yaml
+++ b/src/base/requirements/spatialdata.yaml
@@ -1,3 +1,4 @@
+__merge__: [/src/base/requirements/anndata.yaml, .]
 packages:
   - spatialdata~=0.8.0
   - pyarrow~=18.0.0


### PR DESCRIPTION
Pin `anndata` in the `spatialdata` requirements so that it is consistent between components that use different objects.