### PR TITLE
Add workflows/domains/spatial_leiden_domains workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## NEW FUNCTIONALITY
 
+* `workflows/domains/spatial_leiden_domains`: Workflow to identify spatial domains via Leiden clustering on a fused expression/spatial neighborhood graph (PR #72).
+
 * `mapping/spaceranger_count`, `workflows/ingestion/spaceranger_mapping`, `workflows/ingestion/spaceranger_hd_mapping`: Add `--loupe-alignment` argument and pass all arguments in workflows (PR #69).
 
 * `convert/from_spaceranger_hd_to_spatialdata`: Convert the Space Ranger 4.x cell-segmentation output for Visium HD into a SpatialData object (per-cell counts + cell boundary polygons) (PR #64).

--- a/_viash.yaml
+++ b/_viash.yaml
@@ -15,6 +15,10 @@ repositories:
     repo: openpipeline
     type: vsh
     tag: v4.1.0
+  - name: openpipeline_rapids
+    repo: openpipeline_rapids
+    type: vsh
+    tag: v0.1.2
 
 info:
   test_resources:

--- a/src/workflows/domains/spatial_leiden_domains/config.vsh.yaml
+++ b/src/workflows/domains/spatial_leiden_domains/config.vsh.yaml
@@ -1,0 +1,174 @@
+name: "spatial_leiden_domains"
+namespace: "workflows/domains"
+scope: "public"
+description: |
+  A pipeline to identify spatial domains by fusing an expression k-NN graph
+  with a spatial neighborhood graph and performing Leiden clustering on the
+  fused graph. Produces per-resolution domain labels in `.obsm`.
+
+  Required input:
+    .obsm[--input_obsm_pca]             -  A PCA embedding of the gene expression data.
+    .obsm[--input_obsm_spatial_coords]  -  Spatial coordinates of the observations.
+authors:
+  - __merge__: /src/authors/jakub_majercik.yaml
+    roles: [ author, maintainer ]
+
+argument_groups:
+  - name: Inputs
+    arguments:
+      - name: "--id"
+        required: true
+        type: string
+        description: ID of the sample.
+        example: foo
+      - name: "--input"
+        alternatives: [-i]
+        description: Path to the sample.
+        required: true
+        example: input.h5mu
+        type: file
+      - name: "--modality"
+        description: Which modality to process.
+        type: string
+        default: "rna"
+        required: false
+      - name: "--input_obsm_pca"
+        type: string
+        default: "X_pca"
+        description: Key in `adata.obsm` where the PCA embedding is stored.
+      - name: "--input_obsm_spatial_coords"
+        type: string
+        default: "spatial"
+        description: Key in `adata.obsm` where spatial coordinates are stored.
+
+  - name: "Expression Neighbor Graph"
+    description: |
+      Options for computing the expression k-NN graph from the PCA embedding.
+    arguments:
+      - name: "--expression_num_neighbors"
+        type: integer
+        default: 15
+        description: Number of neighbors to use when computing the expression k-NN graph.
+      - name: "--expression_metric"
+        type: string
+        default: "euclidean"
+        choices: ["euclidean", "l1", "l2", "manhattan", "cityblock", "cosine", "correlation", "chebyshev", "canberra", "minkowski", "sqeuclidean", "jaccard"]
+        description: Distance metric to use when computing the expression k-NN graph.
+      - name: "--expression_random_state"
+        type: integer
+        default: 0
+        description: Random seed used when computing the expression k-NN graph.
+
+  - name: "Spatial Neighbor Graph"
+    description: |
+      Options for the calculation of the spatial neighborhood graph.
+    arguments:
+      - name: "--coord_type"
+        type: string
+        default: "generic"
+        choices: ["generic", "grid"]
+        description: |
+          Type of coordinate system. Valid options are:
+          `grid` - grid coordinates. Only relevant for lattice-based layouts (e.g. Visium). Builds a graph assuming a regular grid topology, where neighbors are defined by grid adjacency rather than distance.
+          `generic` - Generic coordinates. Recommended for imaging-based data. This option is appropriate for irregularly spaced points, such as cell centroids or spot coordinates from imaging-based assays (e.g. Xenium, CosMx). Setting this option avoids grid-assumption artifacts and ensures each node has spatial neighbors as defined by distance.
+      - name: "--n_spatial_neighbors"
+        type: integer
+        default: 6
+        min: 1
+        description: |
+          Depending on `--coord_type`:
+          `grid` - number of neighboring tiles.
+          `generic` - number of neighborhoods for non-grid data. Only used when `--delaunay False`.
+      - name: "--delaunay"
+        type: boolean
+        default: false
+        description: |
+          Whether to use Delaunay triangulation to determine spatial neighborhood graph.
+          Only used when `--coord_type generic`.
+
+  - name: "Graph Fusion"
+    description: |
+      Options for fusing the expression and spatial neighborhood graphs into a single graph.
+      The fusion is a linear combination of the expression connectivities and spatial
+      connectivities matrices, weighted by `--alpha`.
+    arguments:
+      - name: "--alpha"
+        type: double
+        default: 0.5
+        min: 0.0
+        max: 1.0
+        description: |
+          Weight of the spatial graph in the graph fusion.
+          A value of 0 results in the expression graph only;
+          a value of 1 results in the spatial graph only.
+
+  - name: "Leiden Clustering"
+    description: |
+      Options for Leiden clustering on the fused graph.
+    arguments:
+      - name: "--resolution"
+        type: double
+        multiple: true
+        default: [1]
+        description: |
+          Control the coarseness of the clustering. Higher values lead to more clusters.
+          Multiple values will result in clustering being performed multiple times, with
+          one resulting column per resolution stored in `--obsm_output`.
+      - name: "--leiden_n_iterations"
+        type: integer
+        default: 100
+        description: Number of iterations for the Leiden algorithm.
+      - name: "--leiden_random_state"
+        type: integer
+        default: 0
+        description: Random seed for the Leiden algorithm.
+      - name: "--obsm_output"
+        type: string
+        default: "leiden_domains"
+        description: |
+          Key in `adata.obsm` under which to store the per-resolution spatial domain labels,
+          one column per value specified in `--resolution`.
+
+  - name: "Compute"
+    arguments:
+      - name: "--device_type"
+        type: string
+        choices: ["cpu", "gpu"]
+        default: "gpu"
+        description: |
+          Whether to run the expression neighbor graph and Leiden clustering steps on CPU or GPU.
+          GPU execution requires a CUDA-capable GPU to be available.
+
+  - name: "Outputs"
+    arguments:
+      - name: "--output"
+        type: file
+        required: true
+        direction: output
+        description: Destination path to the output.
+        example: output.h5mu
+    __merge__: [., /src/base/h5_compression_argument.yaml]
+
+dependencies:
+  - name: wrappers/preprocessing/neighbors
+    repository: openpipeline_rapids
+    alias: expression_neighbors
+  - name: neighbors/spatial_neighborhood_graph
+  - name: neighbors/join_graphs
+  - name: wrappers/tools/leiden
+    repository: openpipeline_rapids
+    alias: leiden
+
+resources:
+  - type: nextflow_script
+    path: main.nf
+    entrypoint: run_wf
+
+test_resources:
+  - type: nextflow_script
+    path: test.nf
+    entrypoint: test_wf
+  - path: /resources_test/xenium/xenium_tiny.qc.all_neighbors.pca.h5mu
+
+runners:
+  - type: nextflow

--- a/src/workflows/domains/spatial_leiden_domains/integration_test.sh
+++ b/src/workflows/domains/spatial_leiden_domains/integration_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# get the root of the directory
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# ensure that the command below is run from the root of the repository
+cd "$REPO_ROOT"
+
+nextflow \
+  run . \
+  -main-script src/workflows/domains/spatial_leiden_domains/test.nf \
+  -entry test_wf \
+  -profile docker,no_publish \
+  -c src/workflows/utils/labels_ci.config \
+  -c src/workflows/utils/integration_tests.config

--- a/src/workflows/domains/spatial_leiden_domains/main.nf
+++ b/src/workflows/domains/spatial_leiden_domains/main.nf
@@ -1,0 +1,83 @@
+workflow run_wf {
+  take:
+    input_ch
+
+  main:
+    output_ch = input_ch
+
+    | map { id, state ->
+      [id, state + [workflow_output: state.output]]
+    }
+
+    // Compute the expression k-NN graph from the PCA embedding
+    | expression_neighbors.run(
+      fromState: [
+        "input": "input",
+        "modality": "modality",
+        "obsm_input": "input_obsm_pca",
+        "device_type": "device_type",
+        "num_neighbors": "expression_num_neighbors",
+        "metric": "expression_metric",
+        "random_state": "expression_random_state",
+        "output_compression": "output_compression",
+        "output": "workflow_output",
+      ],
+      toState: ["input": "output"]
+    )
+
+    // Compute the spatial neighborhood graph from the spatial coordinates
+    | spatial_neighborhood_graph.run(
+      fromState: [
+        "input": "input",
+        "modality": "modality",
+        "input_obsm_spatial_coords": "input_obsm_spatial_coords",
+        "coord_type": "coord_type",
+        "n_spatial_neighbors": "n_spatial_neighbors",
+        "delaunay": "delaunay",
+        "output_compression": "output_compression",
+        "output": "workflow_output",
+      ],
+      toState: ["input": "output"]
+    )
+
+    // Fuse the expression and spatial neighborhood graphs
+    | join_graphs.run(
+      fromState: [
+        "input": "input",
+        "modality": "modality",
+        "alpha": "alpha",
+        "output_compression": "output_compression",
+        "output": "workflow_output",
+      ],
+      args: [
+        "input_obsp_expression_graph": "connectivities",
+        "input_obsp_spatial_graph": "spatial_connectivities",
+        "output_obsp_graph": "spatial_expression_connectivities",
+      ],
+      toState: ["input": "output"]
+    )
+
+    // Leiden clustering on the fused graph
+    | leiden.run(
+      fromState: [
+        "input": "input",
+        "modality": "modality",
+        "device_type": "device_type",
+        "resolution": "resolution",
+        "n_iterations": "leiden_n_iterations",
+        "random_state": "leiden_random_state",
+        "obsm_name": "obsm_output",
+        "output_compression": "output_compression",
+        "output": "workflow_output",
+      ],
+      args: [
+        "obsp_connectivities": "spatial_expression_connectivities",
+      ],
+      toState: ["output": "output"]
+    )
+
+    | setState(["output": "output"])
+
+  emit:
+    output_ch
+}

--- a/src/workflows/domains/spatial_leiden_domains/nextflow.config
+++ b/src/workflows/domains/spatial_leiden_domains/nextflow.config
@@ -1,0 +1,10 @@
+manifest {
+  nextflowVersion = '!>=20.12.1-edge'
+}
+
+params {
+  rootDir = java.nio.file.Paths.get("$projectDir/../../../../").toAbsolutePath().normalize().toString()
+}
+
+// include common settings
+includeConfig("${params.rootDir}/src/workflows/utils/labels.config")

--- a/src/workflows/domains/spatial_leiden_domains/test.nf
+++ b/src/workflows/domains/spatial_leiden_domains/test.nf
@@ -1,0 +1,41 @@
+nextflow.enable.dsl=2
+targetDir = params.rootDir + "/target/nextflow"
+
+include { spatial_leiden_domains } from targetDir + "/workflows/domains/spatial_leiden_domains/main.nf"
+
+params.resources_test = params.rootDir + "/resources_test"
+
+workflow test_wf {
+
+  resources_test = file(params.resources_test)
+
+  output_ch = Channel.fromList([
+    [
+      id: "xenium",
+      input: resources_test.resolve("xenium/xenium_tiny.qc.all_neighbors.pca.h5mu"),
+      output: "output.h5mu",
+      device_type: "cpu",
+      resolution: [0.5, 1.0],
+    ]
+  ])
+  | map { state -> [state.id, state] }
+  | spatial_leiden_domains
+  | view { output ->
+    assert output.size() == 2 : "outputs should contain two elements; [id, state]"
+
+    def id = output[0]
+    assert id == "xenium"
+
+    def state = output[1]
+    assert state instanceof Map : "State should be a map. Found: ${state}"
+    assert state.containsKey("output") : "Output should contain key 'output'."
+    assert state.output.isFile() : "'output' should be a file."
+    assert state.output.toString().endsWith(".h5mu") : "Output file should end with '.h5mu'. Found: ${state.output}"
+
+    "Output: $output"
+  }
+  | toSortedList()
+  | map { output_list ->
+    assert output_list.size() == 1 : "output channel should contain one event"
+  }
+}


### PR DESCRIPTION
## Summary

- New public workflow `workflows/domains/spatial_leiden_domains`: fuses an expression k-NN graph with a spatial neighborhood graph and runs Leiden clustering on the joint graph, producing per-resolution spatial domain labels in `.obsm`.
- Chains `wrappers/preprocessing/neighbors` and `wrappers/tools/leiden` (from `openpipeline_rapids`, newly pinned at `v0.1.2` in `_viash.yaml`) with the existing local `neighbors/spatial_neighborhood_graph` and `neighbors/join_graphs` components.
- Extracted from an inline pipeline stage in the sibling `pfizer-spatial` repo into a reusable workflow here.

## Test plan

- [x] `viash ns build --setup cb -n '^neighbors$|^workflows/domains$'` builds cleanly
- [x] `bash src/workflows/domains/spatial_leiden_domains/integration_test.sh` passes end-to-end (CPU) against `resources_test/xenium/xenium_tiny.qc.all_neighbors.pca.h5mu`
- [x] Verified output `.obsm['leiden_domains']` has one column per resolution (`['0.5', '1.0']`) alongside preserved `X_pca`/`spatial`
- [ ] CI passes on this PR

## Follow-ups (not in this PR)

- CosMx and Visium don't have a QC+PCA+neighbors fixture equivalent to `xenium_tiny.qc.all_neighbors.pca.h5mu`; broader test coverage for this workflow (and `join_graphs`) would need `resources_test_scripts/cosmx_tiny.sh`/`visium_tiny.sh` extended with the same chain used in `xenium_tiny.sh`.
- Proposed integration into `workflows/multiomics/spatial_process_samples` as an optional gated step, documented in the implementation plan but not built here.